### PR TITLE
CI: Antlr4 Check to validate ANTLR4 grammar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Parse grammar
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Parse ANLTR4 Grammar
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Antlr4
+        uses: StoneMoe/setup-antlr4@v4.13.2
+
+      - name: Run ANTLR4 on grammar
+        run: antlr4 *.g4


### PR DESCRIPTION
Add basic Antlr4 grammar validation workflow

P.s. the workflow probably doesn't trigger because workflows are disabled for non-maintainer contributors